### PR TITLE
Fix Self Caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@
  * @returns {string}
  */
 module.exports = () => {
-  delete require.cache[module.parent.filename];
+	delete require.cache[module.parent.filename];
+	delete require.cache[__filename];
   var parent = module.parent.parent;
   while (parent) {
     try {


### PR DESCRIPTION
Require Function caches modules and file paths. This resulted in it returning same instance of the requiredFrom function when it was required in multiple modules in the dependency tree because of which requiredFrom() returned duplicate paths irrespective of which module it was called in.

The cache was cleared dynamically to fix this.